### PR TITLE
move itests into a profile; don't build...

### DIFF
--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -26,12 +26,17 @@
   <version>3.6.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <properties>
-	  <skipITests>false</skipITests>
-  </properties>
-
-  <modules>
-    <module>org.eclipse.jst.server.tomcat.core.tests</module>
-    <module>org.eclipse.jst.server.tomcat.ui.tests</module>
-  </modules>
+  <profiles>
+    <profile>
+      <id>itests</id>
+      <properties>
+        <skipITests>false</skipITests>
+      </properties>
+      <modules>
+        <module>org.eclipse.jst.server.tomcat.core.tests</module>
+        <module>org.eclipse.jst.server.tomcat.ui.tests</module>
+        <module>../features/org.eclipse.jst.server_adapters.ext_tests.feature</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
   <modules>
     <module>features/org.eclipse.jst.server_adapters.ext.feature</module>
     <module>features/org.eclipse.jst.server_adapters.ext.sdk.feature</module>
-    <module>features/org.eclipse.jst.server_adapters.ext_tests.feature</module>
     <module>features/org.eclipse.jst.server_adapters.feature</module>
     <module>features/org.eclipse.jst.server_adapters.sdk.feature</module>
     <module>features/org.eclipse.jst.server_core.feature</module>


### PR DESCRIPTION
move itests into a profile; don't build features/org.eclipse.jst.server_adapters.ext_tests.feature unless we're building itests plugins too

Signed-off-by: nickboldt <nboldt@redhat.com>